### PR TITLE
Prevent showing config window at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,44 +1,6 @@
 
-.vs/Job Icons/v16/.suo
-.vs/Job Icons/v16/Server/sqlite3/db.lock
-.vs/Job Icons/v16/Server/sqlite3/storage.ide
-.vs/Job Icons/v16/Server/sqlite3/storage.ide-shm
-.vs/Job Icons/v16/Server/sqlite3/storage.ide-wal
-bin/Debug/CheapLoc.dll
-bin/Debug/Dalamud.dll
-bin/Debug/Discord.Net.Core.dll
-bin/Debug/Discord.Net.Rest.dll
-bin/Debug/Discord.Net.WebSocket.dll
-bin/Debug/EasyHook.dll
-bin/Debug/ImGui.NET.dll
-bin/Debug/ImGuiScene.dll
-bin/Debug/JobIcons.dll
-bin/Debug/JobIcons.pdb
-bin/Debug/Lumina.dll
-bin/Debug/Lumina.Generated.dll
-bin/Debug/Microsoft.Bcl.AsyncInterfaces.dll
-bin/Debug/Newtonsoft.Json.dll
-bin/Debug/OpenGL.Net.dll
-bin/Debug/SDL2-CS.dll
-bin/Debug/Serilog.dll
-bin/Debug/Serilog.Sinks.Async.dll
-bin/Debug/Serilog.Sinks.File.dll
-bin/Debug/SharpDX.Desktop.dll
-bin/Debug/SharpDX.Direct3D11.dll
-bin/Debug/SharpDX.dll
-bin/Debug/SharpDX.DXGI.dll
-bin/Debug/SharpDX.Mathematics.dll
-bin/Debug/StbiSharp.dll
-bin/Debug/System.Buffers.dll
-bin/Debug/System.Collections.Immutable.dll
-bin/Debug/System.Drawing.Common.dll
-bin/Debug/System.Linq.Async.dll
-bin/Debug/System.Memory.dll
-bin/Debug/System.Numerics.Vectors.dll
-bin/Debug/System.Runtime.CompilerServices.Unsafe.dll
-bin/Debug/System.Threading.Tasks.Extensions.dll
-obj/Debug/Job Icons.csprojAssemblyReference.cache
-obj/Debug/JobIcons.dll
-obj/Debug/JobIcons.pdb
+.vs
+bin
+obj
 Properties/AssemblyInfo.cs
 .gitattributes

--- a/Job Icons.csproj
+++ b/Job Icons.csproj
@@ -34,15 +34,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Dalamud">
-      <HintPath>..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\Dalamud.dll</HintPath>
+      <HintPath>$(APPDATA)\XIVLauncher\addon\Hooks\Dalamud.dll</HintPath>
     </Reference>
     <Reference Include="ImGui.NET">
-      <HintPath>..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\ImGui.NET.dll</HintPath>
+      <HintPath>$(APPDATA)\XIVLauncher\addon\Hooks\ImGui.NET.dll</HintPath>
     </Reference>
     <Reference Include="ImGuiScene">
-      <HintPath>..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\ImGuiScene.dll</HintPath>
+      <HintPath>$(APPDATA)\XIVLauncher\addon\Hooks\ImGuiScene.dll</HintPath>
     </Reference>
-    <Reference Include="Lumina.Generated, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
+    <Reference Include="Lumina.Generated, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>$(APPDATA)\XIVLauncher\addon\Hooks\Lumina.Generated.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/JobIcons.cs
+++ b/JobIcons.cs
@@ -54,7 +54,7 @@ namespace Job_Icons
 
         public bool help = false;
         public bool enabled = true;
-        public bool config = true;
+        public bool config = false;
         public bool dev = false;
         public bool debug = false;
 
@@ -133,6 +133,7 @@ namespace Job_Icons
 
             role = Configuration.Role;
             enabled = Configuration.Enabled;
+            config = Configuration.ShowConfigAtStartup;
             scaler = Configuration.Scale;
             xAdjust = Configuration.XAdjust;
             yAdjust = Configuration.YAdjust;
@@ -656,6 +657,7 @@ namespace Job_Icons
     {
         public int Version { get; set; } = 0;
         public bool Enabled { get; set; } = true;
+        public bool ShowConfigAtStartup { get; set; } = false;
         public float Scale { get; set; } = 1f;
         public int[] Role { get; set; } = { 0, 0, 0, 0, 0};
         public int XAdjust { get; set; } = -13;


### PR DESCRIPTION
- Prevent showing config window at startup
- Add a config entry to keep showing it at startup
- Simplify the `.gitignore` file by only listing the folders