### PR TITLE
Making it better, faster, stronger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 bin/
 obj/
 .gitattributes
-lib/FFXIVClientStructs/
+lib/FFXIVClientStructs

--- a/IconSet.cs
+++ b/IconSet.cs
@@ -69,7 +69,7 @@ namespace JobIcons
                 94534, 94535, 94536, 94537, 94538, 94539, 94540, 94541, 94579, 94580,
                 94581, 94582, 94583, 94584, 94585, 94530, 94586, 94587, 94621, 94622,
                 94625, 94623, 94624, 94627, 94628, 94629, 94630, 94631 }, 2);
-            Add("Role", new int[] {
+            Add("Role", new int[] { 
                 62581, 62584, 62581, 62584, 62586, 62582, 62502, 62502, 62503, 62504,
                 62505, 62506, 62507, 62508, 62509, 62510, 62511, 62512, 62581, 62584,
                 62581, 62584, 62586, 62582, 62587, 62587, 62587, 62582, 62584, 62584,
@@ -106,7 +106,7 @@ namespace JobIcons
 
         private IconSet(string name, int[] icons, float scaleMultiplier)
         {
-            var numJobs = Enum.GetNames(typeof(Job)).Length;
+            var numJobs = Enum.GetNames(typeof(Job)).Length - 1;
             if (icons.Length != numJobs)
                 throw new ArgumentException($"IconSet was provided {icons.Length} icons, expected {numJobs}");
 
@@ -124,6 +124,7 @@ namespace JobIcons
 
         public int GetIconID(uint jobID)
         {
+            // SUBTRACT FROM JOBID HERE
             var job = (Job)jobID - 1;
             if (IconMethod != null)
             {

--- a/Job.cs
+++ b/Job.cs
@@ -4,6 +4,7 @@ namespace JobIcons
 {
     internal enum Job : uint
     {
+        ADV = 0,
         GLA = 1,
         PGL = 2,
         MRD = 3,
@@ -46,6 +47,7 @@ namespace JobIcons
 
     internal static class JobExtensions
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0066:Convert switch statement to expression", Justification = "No, it looks dumb")]
         public static JobRole GetRole(this Job job)
         {
             switch (job)

--- a/Job.cs
+++ b/Job.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace JobIcons
 {

--- a/JobIcons.csproj
+++ b/JobIcons.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <PackageReference Include="DalamudPackager" Version="1.2.0" />
     <PackageReference Include="ILRepack" Version="2.0.18" GeneratePathProperty="true" />
+    <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <ProjectReference Include="$(SolutionDir)lib\FFXIVClientStructs\FFXIVClientStructs.csproj" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(DalamudLibPath)Newtonsoft.Json.dll</HintPath>

--- a/JobIconsGui.cs
+++ b/JobIconsGui.cs
@@ -314,7 +314,11 @@ namespace JobIcons
                         }
                         else
                         {
-                            var headers = new string[] { "Index", "npObj", "Visible", "IsPlayer", "Layer", "XAdjust", "YAdjust", "XPos", "YPos", "XScale", "YScale", "Type", "npInfo", "ActorID", "Name", "PrefixTitle", "Title", "FcName", "LevelText" };
+                            var headers = new string[] {
+                                "Index",
+                                "npObj", "Visible", "isLocalPlayer", "Layer", "XAdjust", "YAdjust", "XPos", "YPos", "XScale", "YScale", "Type",
+                                "npInfo", "ActorID", "Name", "isPC", "isParty", "isAlliance", "JobID", "PrefixTitle", "Title", "FcName", "LevelText"
+                            };
                             var sizes = new float[headers.Length];
 
                             ImGui.Columns(headers.Length);
@@ -368,6 +372,10 @@ namespace JobIcons
                                 DebugTableCell($"0x{npInfo.Pointer.ToInt64():X}", sizes);
                                 DebugTableCell(npInfo.Data.ActorID.ToString(), sizes);
                                 DebugTableCell(npInfo.Name, sizes);
+                                DebugTableCell(XivApi.IsPlayerCharacter(npInfo.Data.ActorID).ToString(), sizes);
+                                DebugTableCell(XivApi.IsPartyMember(npInfo.Data.ActorID).ToString(), sizes);
+                                DebugTableCell(XivApi.IsAllianceMember(npInfo.Data.ActorID).ToString(), sizes);
+                                DebugTableCell(XivApi.GetJobId(npInfo.Data.ActorID).ToString(), sizes);
                                 DebugTableCell(npInfo.Data.IsPrefixTitle.ToString(), sizes);
                                 DebugTableCell(npInfo.Title, sizes);
                                 DebugTableCell(npInfo.FcName, sizes);
@@ -427,15 +435,11 @@ namespace JobIcons
                     if (actorID == -1)
                         continue;
 
-                    var actor = plugin.GetActor(actorID);
-                    if (actor == null)
+                    if (!npInfo.IsPlayerCharacter())  // Only PlayerCharacters can have icons
                         continue;
 
-                    var pc = plugin.AsPlayerCharacter(actor);
-                    if (pc == null)
-                        continue;
-
-                    if (pc.ClassJob.Id == 0)
+                    var jobID = npInfo.GetJobID();
+                    if (jobID < 1 || jobID >= Enum.GetValues(typeof(Job)).Length)
                         continue;
 
                     var isLocalPlayer = XivApi.IsLocalPlayer(actorID);
@@ -449,8 +453,8 @@ namespace JobIcons
 
                     if (updateLocalPlayer || updatePartyMember || updateAllianceMember || updateEveryoneElse)
                     {
-                        var iconSet = Configuration.GetIconSet(pc.ClassJob.Id);
-                        // var iconID = iconSet.GetIconID(pc.ClassJob.Id);
+                        var iconSet = Configuration.GetIconSet(jobID);
+                        // var iconID = iconSet.GetIconID(jobID);
                         var scaleMult = iconSet.ScaleMultiplier;
 
                         npObject.SetIconScale(Configuration.Scale * scaleMult);

--- a/JobIconsPlugin.cs
+++ b/JobIconsPlugin.cs
@@ -171,6 +171,7 @@ namespace JobIcons
             var jobID = npInfo.GetJobID();
             if (jobID < 1 || jobID >= Enum.GetValues(typeof(Job)).Length)
             {
+                // This may not necessarily be needed anymore, but better safe than sorry.
                 var cache = LastKnownJobID[(object)actorID];
                 if (cache == null)
                     return SetNamePlateHook.Original(namePlateObjectPtr, isPrefixTitle, displayTitle, title, name, fcName, iconID);

--- a/JobRole.cs
+++ b/JobRole.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace JobIcons
 {

--- a/PluginAddressResolver.cs
+++ b/PluginAddressResolver.cs
@@ -21,10 +21,13 @@ namespace JobIcons
     internal delegate IntPtr UIModule_GetRaptureAtkModuleDelegate(IntPtr uiModule);
 
     [UnmanagedFunctionPointer(CallingConvention.ThisCall, CharSet = CharSet.Ansi)]
-    public delegate byte GroupManager_IsObjectIDInPartyDelegate(IntPtr groupManager, int actorId);
+    internal delegate byte GroupManager_IsObjectIDInPartyDelegate(IntPtr groupManager, int actorId);
 
     [UnmanagedFunctionPointer(CallingConvention.ThisCall, CharSet = CharSet.Ansi)]
-    public delegate byte GroupManager_IsObjectIDInAllianceDelegate(IntPtr groupManager, int actorId);
+    internal delegate byte GroupManager_IsObjectIDInAllianceDelegate(IntPtr groupManager, int actorId);
+
+    [UnmanagedFunctionPointer(CallingConvention.ThisCall, CharSet = CharSet.Ansi)]
+    internal delegate IntPtr BattleCharaStore_LookupBattleCharaByObjectIDDelegate(IntPtr battleCharaStore, int actorId);
 
     internal sealed class PluginAddressResolver : BaseAddressResolver
     {
@@ -49,6 +52,12 @@ namespace JobIcons
         private const string GroupManager_IsObjectIDInAllianceSignature = "33 C0 44 8B CA F6 81 ?? ?? ?? ?? ??";
         internal IntPtr GroupManager_IsObjectIDInAlliancePtr;
 
+        private const string BattleCharaStoreSignature = "8B D0 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B D8 48 85 C0 74 3A";
+        internal IntPtr BattleCharaStorePtr;
+
+        private const string BattleCharaStore_LookupBattleCharaByObjectIDSignature = "E8 ?? ?? ?? ?? 48 8B D8 48 85 C0 74 3A 48 8B C8";
+        internal IntPtr BattleCharaStore_LookupBattleCharaByObjectIDPtr;
+        
         protected override void Setup64Bit(SigScanner scanner)
         {
             AddonNamePlate_SetNamePlatePtr = scanner.ScanText(AddonNamePlate_SetNamePlateSignature);
@@ -58,6 +67,8 @@ namespace JobIcons
             GroupManagerPtr = scanner.GetStaticAddressFromSig(GroupManagerSignature);
             GroupManager_IsObjectIDInPartyPtr = scanner.ScanText(GroupManager_IsObjectIDInPartySignature);
             GroupManager_IsObjectIDInAlliancePtr = scanner.ScanText(GroupManager_IsObjectIDInAllianceSignature);
+            BattleCharaStorePtr = scanner.GetStaticAddressFromSig(BattleCharaStoreSignature);
+            BattleCharaStore_LookupBattleCharaByObjectIDPtr = scanner.ScanText(BattleCharaStore_LookupBattleCharaByObjectIDSignature);
         }
     }
 }

--- a/XivApi.cs
+++ b/XivApi.cs
@@ -232,10 +232,11 @@ namespace JobIcons
 
             public unsafe bool IsLocalPlayer => Data.IsLocalPlayer;
 
-            public void SetIconScale(float scale)
+            public void SetIconScale(float scale, bool force = false)
             {
-                Instance.SetNodeScale(IconImageNodeAddress, scale, scale);
-                
+                if (force || IconImageNode.AtkResNode.ScaleX != scale || IconImageNode.AtkResNode.ScaleY != scale)
+                    Instance.SetNodeScale(IconImageNodeAddress, scale, scale);
+
                 //var imageNodePtr = IconImageNodeAddress;
                 //var resNodePtr = imageNodePtr + Marshal.OffsetOf(typeof(AtkImageNode), nameof(AtkImageNode.AtkResNode)).ToInt32();
                 //var scaleXPtr = resNodePtr + Marshal.OffsetOf(typeof(AtkResNode), nameof(AtkResNode.ScaleX)).ToInt32();
@@ -250,17 +251,21 @@ namespace JobIcons
                 //imageNode->AtkResNode.ScaleY = scale;
             }
 
-            public void SetIconPosition(short x, short y)
+            public void SetIconPosition(short x, short y, bool force = false)
             {
+                if (force || Data.IconXAdjust != x || Data.IconYAdjust != y)
+                {
+                    var iconXAdjustPtr = Pointer + Marshal.OffsetOf(typeof(AddonNamePlate.NamePlateObject), nameof(AddonNamePlate.NamePlateObject.IconXAdjust)).ToInt32();
+                    var iconYAdjustPtr = Pointer + Marshal.OffsetOf(typeof(AddonNamePlate.NamePlateObject), nameof(AddonNamePlate.NamePlateObject.IconYAdjust)).ToInt32();
+                    Marshal.WriteInt16(iconXAdjustPtr, x);
+                    Marshal.WriteInt16(iconYAdjustPtr, y);
+                }
+
+                //Instance.SetNodePosition(IconImageNodeAddress, x, y);
                 //npObject->ImageNode1->AtkResNode.X = 0;
                 //npObject->ImageNode1->AtkResNode.Y = 0;
                 //npObject->IconXAdjust = x;
                 //npObject->IconYAdjust = y;
-                var iconXAdjustPtr = Pointer + Marshal.OffsetOf(typeof(AddonNamePlate.NamePlateObject), nameof(AddonNamePlate.NamePlateObject.IconXAdjust)).ToInt32();
-                var iconYAdjustPtr = Pointer + Marshal.OffsetOf(typeof(AddonNamePlate.NamePlateObject), nameof(AddonNamePlate.NamePlateObject.IconYAdjust)).ToInt32();
-                Marshal.WriteInt16(iconXAdjustPtr, x);
-                Marshal.WriteInt16(iconYAdjustPtr, y);
-                //Instance.SetNodePosition(IconImageNodeAddress, x, y);
             }
         }
 


### PR DESCRIPTION
P. sure this solves scale flickering.

When using everyone-icons, xiv-combo replacements can start flickering. I think its due to too many nodes altered? So updated those to only change if the values are different.

I did have one CTD right near the end while I was writing this up, so it still needs some testing.  Cursed amounts of debug statements and such, but its a drastic improvement.